### PR TITLE
Adding support for layout components

### DIFF
--- a/assets/components.js
+++ b/assets/components.js
@@ -1,11 +1,27 @@
 App.on("field.layout.components", function(field) {
+  function handleComponents(op, which) {
+    Object.keys(field.params.components).forEach(function(key) {
+      if ((op === "enable" && !which.includes(key)) || (op === "disable" && which.includes(key))) {
+        delete field.params.components[key]
+      }
+    })
+  }
+
   window.setTimeout(function() {
     if (field.params.opts && field.params.opts.enabled !== undefined) {
-      Object.keys(field.params.components).forEach(function(key) {
-        if (!field.params.opts.enabled.includes(key)) {
-          delete field.params.components[key];
-        }
-      });
+      handleComponents("enable", field.params.opts.enabled)
     }
-  }, 100);
-});
+
+    if (field.params.opts.parent && field.params.opts.parent.enabled !== undefined) {
+      handleComponents("enable", field.params.opts.parent.enabled)
+    }
+
+    if (field.params.opts && field.params.opts.disabled !== undefined) {
+      handleComponents("disable", field.params.opts.disabled)
+    }
+
+    if (field.params.opts.parent && field.params.opts.parent.disabled !== undefined) {
+      handleComponents("disable", field.params.opts.parent.disabled)
+    }
+  }, 100)
+})


### PR DESCRIPTION
This adds the same functionality for CustomComponents as for the layout field on Collections. 

Options for LayoutComponents are added in agentejo/LayoutComponents#4

Those options are exposed in agentejo/cockpit#1091 for this implementation.

I also added an option to disable components. 